### PR TITLE
feat: 데이터 받아오기, 최근 10개 기록만 출력

### DIFF
--- a/src/components/main/LogCard.tsx
+++ b/src/components/main/LogCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Typography from "../typography";
 import { css } from "styled-components";
 import { format } from "date-fns";
@@ -6,6 +6,7 @@ import theme from "../../constants/theme";
 import DEVICE_LIST from "../../constants/device";
 import { applyMediaQuery } from "../../styles/mediaQuery";
 import CardTemplate from "../cardTemplate";
+import { Log, LogCardProps } from "../../types/log";
 
 const responseCardFonts = {
   mobile: theme.fontSize.body2b_mobile,
@@ -23,19 +24,8 @@ const responseCardWidths = {
   wideDesktop: "806px",
 };
 
-const LogCard = () => {
-  const data = [
-    {
-      inOut: "in",
-      date: new Date(2022, 8, 15, 16, 0),
-      type: "중앙도서관",
-    },
-    {
-      inOut: "in",
-      date: new Date(2022, 8, 15, 17, 30),
-      type: "정보과학관",
-    },
-  ];
+const LogCard = (prop: LogCardProps) => {
+  const [data, setData] = useState<Log[]>(prop.data);
   const buildings = [
     "모든 건물",
     "중앙도서관",
@@ -50,18 +40,22 @@ const LogCard = () => {
     "신양관",
   ];
 
-  const [filteredData, setFilteredData] = useState(data);
+  const [filteredData, setFilteredData] = useState<Log[]>(prop.data);
+
   const getFilterData = (option: string) => {
-    if (option === "모든 건물") setFilteredData(data);
-    else
-      setFilteredData(
-        data.filter((log: { type: string }) => log.type === option)
-      );
+    if (option === "모든 건물") setFilteredData(data.slice(0, 10));
+    else setFilteredData(data.filter((log: Log) => log.type === option));
   };
 
   const changeOption = (e: React.ChangeEvent<HTMLSelectElement>) => {
     getFilterData(e.target.value);
   };
+
+  useEffect(() => {
+    setData(prop.data);
+    setFilteredData(prop.data);
+    getFilterData("모든 건물");
+  }, [prop]);
 
   return (
     <div>
@@ -76,33 +70,31 @@ const LogCard = () => {
       </div>
 
       <div>
-        {filteredData.map(
-          (d: { inOut: string; date: Date; type: string }, index) => (
-            <CardTemplate key={index} css={responseCardCss}>
-              <div>
-                <Typography
-                  as="p"
-                  weight="semiBold"
-                  lineHeight={1.06}
-                  css={responsiveCardFontCss}
-                >
-                  {d.inOut === "in" ? "입장" : "퇴장"}
-                </Typography>
-                <Typography
-                  as="p"
-                  weight="semiBold"
-                  color="gray_5"
-                  css={responsiveCardFontCss}
-                >
-                  {format(d.date, "LL.dd kk:mm")}
-                </Typography>
-              </div>
-              <Typography as="p" weight="semiBold" css={responsiveCardFontCss}>
-                {d.type}
+        {filteredData.map((d: Log, index: number) => (
+          <CardTemplate key={index} css={responseCardCss}>
+            <div>
+              <Typography
+                as="p"
+                weight="semiBold"
+                lineHeight={1.06}
+                css={responsiveCardFontCss}
+              >
+                {d.inOut === "in" ? "입장" : "퇴장"}
               </Typography>
-            </CardTemplate>
-          )
-        )}
+              <Typography
+                as="p"
+                weight="semiBold"
+                color="gray_5"
+                css={responsiveCardFontCss}
+              >
+                {format(new Date(d.date), "LL.dd kk:mm")}
+              </Typography>
+            </div>
+            <Typography as="p" weight="semiBold" css={responsiveCardFontCss}>
+              {d.type}
+            </Typography>
+          </CardTemplate>
+        ))}
       </div>
     </div>
   );

--- a/src/components/main/LogCard.tsx
+++ b/src/components/main/LogCard.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import Typography from "../typography";
 import { css } from "styled-components";
-import { format } from "date-fns";
+import { format, compareDesc } from "date-fns";
 import theme from "../../constants/theme";
 import DEVICE_LIST from "../../constants/device";
 import { applyMediaQuery } from "../../styles/mediaQuery";
@@ -51,8 +51,14 @@ const LogCard = (prop: LogCardProps) => {
     getFilterData(e.target.value);
   };
 
+  const sortForDate = (array: Log[]) => {
+    return array.sort((a, b) =>
+      compareDesc(new Date(a.date), new Date(b.date))
+    );
+  };
+
   useEffect(() => {
-    setData(prop.data);
+    setData(sortForDate(prop.data));
     setFilteredData(prop.data);
     getFilterData("모든 건물");
   }, [prop]);

--- a/src/components/main/LogCard.tsx
+++ b/src/components/main/LogCard.tsx
@@ -59,8 +59,7 @@ const LogCard = (prop: LogCardProps) => {
 
   useEffect(() => {
     setData(sortForDate(prop.data));
-    setFilteredData(prop.data);
-    getFilterData("모든 건물");
+    setFilteredData(sortForDate(prop.data).slice(0, 10));
   }, [prop]);
 
   return (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -43,6 +43,76 @@ const worker = setupWorker(
         },
       })
     );
+  }),
+  rest.get("https://server.com/members/allLog", (req, res, ctx) => {
+    return res(
+      ctx.json({
+        data: {
+          data: [
+            {
+              inOut: "in",
+              date: new Date(2022, 8, 15, 17, 0),
+              type: "중앙도서관",
+            },
+            {
+              inOut: "out",
+              date: new Date(2022, 8, 15, 19, 0),
+              type: "중앙도서관",
+            },
+            {
+              inOut: "in",
+              date: new Date(2022, 1, 15, 13, 30),
+              type: "정보과학관",
+            },
+            {
+              inOut: "out",
+              date: new Date(2022, 1, 15, 14, 50),
+              type: "정보과학관",
+            },
+            {
+              inOut: "in",
+              date: new Date(2022, 3, 15, 7, 5),
+              type: "학생회관",
+            },
+            {
+              inOut: "out",
+              date: new Date(2022, 3, 15, 17, 5),
+              type: "학생회관",
+            },
+            {
+              inOut: "in",
+              date: new Date(2022, 3, 15, 7, 5),
+              type: "문화관",
+            },
+            {
+              inOut: "out",
+              date: new Date(2022, 3, 15, 17, 5),
+              type: "문화관",
+            },
+            {
+              inOut: "in",
+              date: new Date(2022, 3, 15, 7, 5),
+              type: "신양관",
+            },
+            {
+              inOut: "out",
+              date: new Date(2022, 3, 15, 17, 5),
+              type: "신양관",
+            },
+            {
+              inOut: "in",
+              date: new Date(2022, 3, 15, 7, 5),
+              type: "안익태기념관",
+            },
+            {
+              inOut: "out",
+              date: new Date(2022, 3, 15, 17, 5),
+              type: "안익태기념관",
+            },
+          ],
+        },
+      })
+    );
   })
 );
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -61,12 +61,12 @@ const worker = setupWorker(
             },
             {
               inOut: "in",
-              date: new Date(2022, 1, 15, 13, 30),
+              date: new Date(2022, 8, 10, 13, 30),
               type: "정보과학관",
             },
             {
               inOut: "out",
-              date: new Date(2022, 1, 15, 14, 50),
+              date: new Date(2022, 8, 10, 14, 50),
               type: "정보과학관",
             },
             {
@@ -81,32 +81,32 @@ const worker = setupWorker(
             },
             {
               inOut: "in",
-              date: new Date(2022, 3, 15, 7, 5),
+              date: new Date(2022, 3, 16, 7, 5),
               type: "문화관",
             },
             {
               inOut: "out",
-              date: new Date(2022, 3, 15, 17, 5),
+              date: new Date(2022, 3, 16, 17, 5),
               type: "문화관",
             },
             {
               inOut: "in",
-              date: new Date(2022, 3, 15, 7, 5),
+              date: new Date(2022, 2, 15, 7, 5),
               type: "신양관",
             },
             {
               inOut: "out",
-              date: new Date(2022, 3, 15, 17, 5),
+              date: new Date(2022, 2, 15, 17, 5),
               type: "신양관",
             },
             {
               inOut: "in",
-              date: new Date(2022, 3, 15, 7, 5),
+              date: new Date(2022, 1, 15, 7, 5),
               type: "안익태기념관",
             },
             {
               inOut: "out",
-              date: new Date(2022, 3, 15, 17, 5),
+              date: new Date(2022, 1, 15, 17, 5),
               type: "안익태기념관",
             },
           ],

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -11,6 +11,7 @@ import type {
   ResponseMemberAmount,
   ResponseMemberMe,
 } from "../types/user";
+import type { LogCardProps } from "../types/log";
 import AsyncBoundary from "../components/asyncBoundary";
 
 const Member = () => {
@@ -36,6 +37,16 @@ const Member = () => {
   );
 };
 
+const BuildingAccess = () => {
+  const {
+    data: LogData,
+    loading: LogLoading,
+    error: LogError,
+  } = useFetch<LogCardProps>("https://server.com/members/allLog", {
+    method: "GET",
+  });
+  return <LogCard data={[]} {...LogData?.data} />;
+};
 const Main = () => {
   return (
     <MainBase>
@@ -46,7 +57,7 @@ const Main = () => {
         <Member />
       </AsyncBoundary>
       <Streak />
-      <LogCard />
+      <BuildingAccess />
     </MainBase>
   );
 };

--- a/src/types/log.ts
+++ b/src/types/log.ts
@@ -1,0 +1,11 @@
+interface Log {
+  inOut: string;
+  date: Date;
+  type: string;
+}
+
+interface LogCardProps {
+  data: Log[];
+}
+
+export type { Log, LogCardProps };


### PR DESCRIPTION
### 반영 브랜치

feature/card -> main

### 변경 사항

1) 모든 건물 (기본값) 에서 최근 10개의 기록만 출력하도록 했습니다.
    * LogCard 컴포넌트에서는 props로 받은 배열을 날짜순으로 정렬합니다

2) 임시 데이터를 삭제하고 Main.tsx 에서 받는 props 값을 이용하도록 바꿨습니다

### 테스트 결과
12개의 데이터 중 가장 오래된 결과 2개 (2월 - 안익태기념관) 는 해당 건물 옵션으로 들어가야만 보이는 모습

![움짤](https://user-images.githubusercontent.com/87255462/190440064-4f480bec-00c9-4f3b-b146-f80e93ee242e.gif)


### Issue

resolved: #20
